### PR TITLE
Better audio route handling

### DIFF
--- a/ios/RNAInputAudioStream.h
+++ b/ios/RNAInputAudioStream.h
@@ -35,6 +35,8 @@ typedef void (^OnChunk)(int chunkId, unsigned char *chunk, int size);
 
 - (void)stop;
 
+- (void)reconfigureInputEngine;
+
 + (RNAInputAudioStream*) streamAudioSource:(enum AUDIO_SOURCES)audioSource
                                 sampleRate:(int)sampleRate
                              channelConfig:(enum CHANNEL_CONFIGS)channelConfig

--- a/ios/RNASamplePlayer.mm
+++ b/ios/RNASamplePlayer.mm
@@ -72,7 +72,7 @@
     if (isSpeakerOutput) {
         AVAudioSession *session = [AVAudioSession sharedInstance];
         [session overrideOutputAudioPort:AVAudioSessionPortOverrideNone error:&error];
-        [session overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&error];
+        [session overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker error:&error]; // Built-in speaker only
         /*
          The output audio port overrides are needed here for playback with echo cancellation to function properly.
          Apple developer forum post here: https://forums.developer.apple.com/forums/thread/721535
@@ -110,8 +110,8 @@
 /**
  * Inits RNASamplePlayer instance.
  */
-- (id) init:(OnError)onError
-       isSpeakerOutput:(BOOL)isSpeakerOutput;
+
+- (id) init:(OnError)onError isSpeakerOutput:(BOOL)isSpeakerOutput;
 {
   self->onError = onError;
   self->isSpeakerOutput = isSpeakerOutput;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/react-native-audio",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "React Native: access to the audio input stream",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
This change better handles `AVAudioSessionRouteChangeNotification` notifications and resolves device I/O in a way that the user most likely intends. Once the input and outputs are selected we need to spin up a new `AVAudioEngine` and re-install the proper taps to get data flowing. This operation is lightweight and happens pretty instantaneously for most device switching operations I was able to test.

The most notable outlier is _disconnecting_ a bluetooth device as it takes a while for the system to register it as disconnected and send along the proper notification. In a real world scenario this is likely not a problem, but something to keep in mind for testing since it's something we don't have any control over (we can just respond to the notifications as they come in).